### PR TITLE
Update tls-api to 0.2

### DIFF
--- a/cowrpc/Cargo.toml
+++ b/cowrpc/Cargo.toml
@@ -27,8 +27,8 @@ futures = "0.1.25"
 parking_lot = "0.6"
 tokio = "0.1.11"
 tokio-tcp = "0.1.2"
-tls-api = "0.1.20"
-tls-api-native-tls = "0.1.20"
+tls-api = "0.2"
+tls-api-native-tls = "0.2"
 
 [dev-dependencies]
 cowrpc_derive = {path = "../cowrpc_derive"}

--- a/cowrpc/src/peer.rs
+++ b/cowrpc/src/peer.rs
@@ -920,7 +920,6 @@ impl CowRpcPeer {
                             error = CowRpcErrorCode::from(header.flags);
                         }
                         return bind_req.tx.send(CowRpcBindRsp { error }).map_err(|e| CowRpcError::Internal(e.to_string()));
-                        ;
                     }
                 }
                 _ => continue, /* Wrong request type, we move to the next one */

--- a/cowrpc/src/transport/async/websocket.rs
+++ b/cowrpc/src/transport/async/websocket.rs
@@ -510,7 +510,7 @@ impl Sink for CowMessageSink {
                 }
             } else {
                 // fragment the buffer
-                use std::io::{Cursor, Read};
+                use std::io::Cursor;
                 let mut cursor = Cursor::new(data_to_send);
                 loop {
                     let mut chunk = Vec::with_capacity(WS_BIN_CHUNK_SIZE);

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -9,7 +9,7 @@ rmp = "0.8.7"
 log = "0.4.1"
 env_logger = "0.5.3"
 ctrlc = { version = "3.0", features = ["termination"] }
-tls-api = "0.1.20"
+tls-api = "0.2"
 
 [dependencies.cowrpc]
 path = "../../cowrpc"


### PR DESCRIPTION
The build currently fails on Ubuntu 19.04 because it is unable to find openssl. Updating tls-api fixes the issue.