### PR TITLE
Update to use tokio 2

### DIFF
--- a/cowrpc/Cargo.toml
+++ b/cowrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cowrpc"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT/Apache-2.0"
 authors = ["François Dubois <fdubois@devolutions.net>, Richer Archambault <rarchambault@devolutions.net>"]
 edition = "2018"
@@ -23,9 +23,10 @@ url = "1.7"
 rand = "0.4"
 mouscache = "^0.5.4"
 mouscache_derive = "0.4"
-futures = "0.1.25"
+futures = "0.1.29"
+futures_03 = { package = "futures", version = "0.3", features = ["compat"] }
 parking_lot = "0.6"
-tokio = "0.1.11"
+tokio = { version = "0.2.11", features = ["full"] }
 tokio-tcp = "0.1.2"
 tls-api = { git = "https://github.com/devolutions/rust-tls-api", branch = "wayk" }
 tls-api-native-tls = { git = "https://github.com/devolutions/rust-tls-api", branch = "wayk" }

--- a/cowrpc/src/transport/async/adaptor.rs
+++ b/cowrpc/src/transport/async/adaptor.rs
@@ -1,10 +1,9 @@
 use crate::error::{CowRpcError, Result};
-use futures::{Async, Stream};
+use futures::{Async, Stream, task};
 use parking_lot::Mutex;
 use crate::proto::CowRpcMessage;
 use std::collections::VecDeque;
 use std::sync::Arc;
-use tokio::prelude::*;
 use super::*;
 
 #[derive(Clone)]

--- a/cowrpc/src/transport/async/tcp.rs
+++ b/cowrpc/src/transport/async/tcp.rs
@@ -7,12 +7,12 @@ use std::{
     net::SocketAddr,
     time::{Duration, Instant},
 };
-use tokio::net::TcpStream;
 use crate::transport::{
     r#async::{Transport, CowFuture, CowSink, CowStream},
     uri::Uri,
     MessageInterceptor, TransportError,
 };
+use tokio_tcp::TcpStream;
 
 pub struct TcpTransport {
     stream: TcpStream,

--- a/cowrpc/src/transport/async/tcp_listener.rs
+++ b/cowrpc/src/transport/async/tcp_listener.rs
@@ -4,7 +4,7 @@ use futures::{
     Stream,
 };
 use std::net::SocketAddr;
-use tokio::net::TcpListener as TcpTokioListener;
+use tokio_tcp::TcpListener as TcpTokioListener;
 use crate::transport::{
     r#async::{Listener, CowFuture, CowStream, tcp::TcpTransport},
     MessageInterceptor,

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -10,6 +10,7 @@ log = "0.4.1"
 env_logger = "0.5.3"
 ctrlc = { version = "3.0", features = ["termination"] }
 tls-api = "0.1.20"
+tokio = "0.2"
 
 [dependencies.cowrpc]
 path = "../../cowrpc"

--- a/examples/router/src/router.rs
+++ b/examples/router/src/router.rs
@@ -4,11 +4,13 @@ extern crate ctrlc;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
+extern crate tokio;
 
 use cowrpc::async_router::CowRpcRouter;
 use cowrpc::transport::tls::{TlsOptionsBuilder};
 
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
 
     let tls_options = TlsOptionsBuilder::new()
@@ -18,7 +20,8 @@ fn main() {
     let (router, _router_handle) = CowRpcRouter::new("wss://router.local:12345", Some(tls_options))
                                                  .expect("new router failed");
 
-    if let Err(e) = router.run() {
+
+    if let Err(e) = router.spawn() {
         error!("Failed to run router: {}", e);
     }
 }


### PR DESCRIPTION
- We still use tokio_tcp::TcpStream.  We should probably move to tokio::net::TcpStream, but it will need more changes because stream is not clonable anymore.  It works for now even if we have warning about "try_clone()" call.
- There is build error in example since we use certificate. But we have an old version of tls-api. We should probably update it.
- Not sure if example were working before those changes. I didn't waste time to test them and fix them for now

- Once den-v1 will be deprecated, we could refactor all that to keep only what is needed (async + removed everything related to bind context)