### PR TITLE
Improve logs

### DIFF
--- a/cowrpc/src/peer/mod.rs
+++ b/cowrpc/src/peer/mod.rs
@@ -94,7 +94,7 @@ impl CowRpcPeer {
         let logger = config
             .logger
             .clone()
-            .unwrap_or_else(|| slog::Logger::root(slog_stdlog::StdLog.fuse(), o!()));
+            .unwrap_or_else(|| slog::Logger::root(slog_stdlog::StdLog.fuse(), o!("type" => "peer")));
 
         let peer_inner = match tokio::time::timeout(
             config.connection_timeout,

--- a/cowrpc/src/router/mod.rs
+++ b/cowrpc/src/router/mod.rs
@@ -229,7 +229,7 @@ impl CowRpcRouterBuilder {
             .unwrap_or_else(|| {
                 slog::Logger::root(
                     slog_stdlog::StdLog.fuse(),
-                    o!("router_id" => format!("{:#010X}", router_id)),
+                    o!("type" => "router", "router_id" => format!("{:#010X}", router_id)),
                 )
             });
 

--- a/cowrpc/src/transport/adaptor.rs
+++ b/cowrpc/src/transport/adaptor.rs
@@ -24,7 +24,7 @@ impl Default for Adaptor {
 }
 
 impl Adaptor {
-    pub fn message_stream(&self) -> CowStream<CowRpcMessage> {
+    pub fn message_stream(&self) -> BoxStream<CowRpcMessage> {
         Box::pin(AdaptorStream {
             messages: self.messages.clone(),
             waker: self.waker.clone(),

--- a/cowrpc/src/transport/interceptor.rs
+++ b/cowrpc/src/transport/interceptor.rs
@@ -5,7 +5,7 @@ use crate::transport::{
 };
 use async_trait::async_trait;
 use futures::prelude::*;
-use slog::Logger;
+use slog::{o, Drain, Logger};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -97,6 +97,10 @@ impl Sink<CowRpcMessage> for InterceptorSink {
 }
 
 impl LoggerObject for InterceptorSink {
+    fn get_logger(&self) -> Logger {
+        slog::Logger::root(slog_stdlog::StdLog.fuse(), o!())
+    }
+
     fn set_logger(&mut self, _: Logger) {}
 }
 
@@ -113,6 +117,10 @@ impl Stream for InterceptorStream {
 }
 
 impl LoggerObject for InterceptorStream {
+    fn get_logger(&self) -> Logger {
+        slog::Logger::root(slog_stdlog::StdLog.fuse(), o!())
+    }
+
     fn set_logger(&mut self, _: Logger) {}
 }
 

--- a/cowrpc/src/transport/interceptor.rs
+++ b/cowrpc/src/transport/interceptor.rs
@@ -1,6 +1,8 @@
 use crate::error::{CowRpcError, Result};
 use crate::proto::CowRpcMessage;
-use crate::transport::{CowSink, CowStream, MessageInterceptor, Transport, TransportError};
+use crate::transport::{
+    CowSink, CowStream, LoggerObject, MessageInterceptor, SinkAndLog, StreamAndLog, Transport, TransportError,
+};
 use async_trait::async_trait;
 use futures::prelude::*;
 use slog::Logger;
@@ -94,6 +96,12 @@ impl Sink<CowRpcMessage> for InterceptorSink {
     }
 }
 
+impl LoggerObject for InterceptorSink {
+    fn set_logger(&mut self, _: Logger) {}
+}
+
+impl SinkAndLog<CowRpcMessage> for InterceptorSink {}
+
 struct InterceptorStream {}
 
 impl Stream for InterceptorStream {
@@ -103,3 +111,9 @@ impl Stream for InterceptorStream {
         Poll::Ready(Some(Err(CowRpcError::Internal("Should never be used".to_string()))))
     }
 }
+
+impl LoggerObject for InterceptorStream {
+    fn set_logger(&mut self, _: Logger) {}
+}
+
+impl StreamAndLog for InterceptorStream {}

--- a/cowrpc/src/transport/mod.rs
+++ b/cowrpc/src/transport/mod.rs
@@ -23,6 +23,7 @@ mod websocket;
 mod websocket_listener;
 
 pub trait LoggerObject {
+    fn get_logger(&self) -> Logger;
     fn set_logger(&mut self, logger: Logger);
 }
 

--- a/cowrpc/src/transport/tcp.rs
+++ b/cowrpc/src/transport/tcp.rs
@@ -1,6 +1,8 @@
 use crate::error::CowRpcError;
 use crate::proto::{CowRpcMessage, Message};
-use crate::transport::{CowSink, CowStream, MessageInterceptor, Transport, TransportError};
+use crate::transport::{
+    CowSink, CowStream, LoggerObject, MessageInterceptor, SinkAndLog, StreamAndLog, Transport, TransportError,
+};
 use async_trait::async_trait;
 use byteorder::{LittleEndian, ReadBytesExt};
 use futures::prelude::*;
@@ -188,6 +190,14 @@ impl Stream for CowMessageStream {
     }
 }
 
+impl LoggerObject for CowMessageStream {
+    fn set_logger(&mut self, logger: Logger) {
+        self.logger = logger;
+    }
+}
+
+impl StreamAndLog for CowMessageStream {}
+
 pub struct CowMessageSink {
     pub stream: OwnedWriteHalf,
     pub data_to_send: Vec<u8>,
@@ -239,3 +249,11 @@ impl Sink<CowRpcMessage> for CowMessageSink {
         Poll::Ready(Ok(()))
     }
 }
+
+impl LoggerObject for CowMessageSink {
+    fn set_logger(&mut self, logger: Logger) {
+        self.logger = logger;
+    }
+}
+
+impl SinkAndLog<CowRpcMessage> for CowMessageSink {}

--- a/cowrpc/src/transport/tcp.rs
+++ b/cowrpc/src/transport/tcp.rs
@@ -191,6 +191,10 @@ impl Stream for CowMessageStream {
 }
 
 impl LoggerObject for CowMessageStream {
+    fn get_logger(&self) -> Logger {
+        self.logger.clone()
+    }
+
     fn set_logger(&mut self, logger: Logger) {
         self.logger = logger;
     }
@@ -251,6 +255,10 @@ impl Sink<CowRpcMessage> for CowMessageSink {
 }
 
 impl LoggerObject for CowMessageSink {
+    fn get_logger(&self) -> Logger {
+        self.logger.clone()
+    }
+
     fn set_logger(&mut self, logger: Logger) {
         self.logger = logger;
     }

--- a/cowrpc/src/transport/tcp_listener.rs
+++ b/cowrpc/src/transport/tcp_listener.rs
@@ -1,6 +1,6 @@
 use crate::error::CowRpcError;
 use crate::transport::tcp::TcpTransport;
-use crate::transport::{CowFuture, CowStream, Listener, MessageInterceptor};
+use crate::transport::{BoxStream, CowFuture, Listener, MessageInterceptor};
 use async_trait::async_trait;
 use futures::future;
 use slog::Logger;
@@ -33,7 +33,7 @@ impl Listener for TcpListener {
         }
     }
 
-    async fn incoming(self) -> CowStream<CowFuture<Self::TransportInstance>> {
+    async fn incoming(self) -> BoxStream<CowFuture<Self::TransportInstance>> {
         let TcpListener {
             listener,
             transport_cb_handler,
@@ -45,7 +45,7 @@ impl Listener for TcpListener {
             let cbh = transport_cb_handler.clone();
             let logger_clone = logger.clone();
             Ok(Box::pin(future::ok(TcpTransport::new(tcp_stream, cbh, logger_clone))) as CowFuture<TcpTransport>)
-        })) as CowStream<CowFuture<Self::TransportInstance>>
+        })) as BoxStream<CowFuture<Self::TransportInstance>>
     }
 
     fn set_msg_interceptor(&mut self, cb_handler: Box<dyn MessageInterceptor>) {

--- a/cowrpc/src/transport/websocket.rs
+++ b/cowrpc/src/transport/websocket.rs
@@ -1,6 +1,9 @@
 use crate::error::{CowRpcError, Result};
 use crate::proto::{CowRpcMessage, Message};
-use crate::transport::{CowRpcTransportError, CowSink, CowStream, MessageInterceptor, Transport, TransportError};
+use crate::transport::{
+    CowRpcTransportError, CowSink, CowStream, LoggerObject, MessageInterceptor, SinkAndLog, StreamAndLog, Transport,
+    TransportError,
+};
 use async_trait::async_trait;
 use async_tungstenite::tokio::{ConnectStream, TokioAdapter};
 use async_tungstenite::tungstenite::{Error as WsError, Message as WsMessage};
@@ -406,6 +409,14 @@ impl Stream for CowMessageStream {
     }
 }
 
+impl LoggerObject for CowMessageStream {
+    fn set_logger(&mut self, logger: Logger) {
+        self.logger = logger;
+    }
+}
+
+impl StreamAndLog for CowMessageStream {}
+
 struct CowMessageSink {
     sink: Arc<AsyncMutex<WsSink>>,
     data_to_send: Vec<u8>,
@@ -486,3 +497,11 @@ impl Sink<CowRpcMessage> for CowMessageSink {
             .map_err(|e| CowRpcTransportError::from(e).into())
     }
 }
+
+impl LoggerObject for CowMessageSink {
+    fn set_logger(&mut self, logger: Logger) {
+        self.logger = logger;
+    }
+}
+
+impl SinkAndLog<CowRpcMessage> for CowMessageSink {}

--- a/cowrpc/src/transport/websocket.rs
+++ b/cowrpc/src/transport/websocket.rs
@@ -410,6 +410,10 @@ impl Stream for CowMessageStream {
 }
 
 impl LoggerObject for CowMessageStream {
+    fn get_logger(&self) -> Logger {
+        self.logger.clone()
+    }
+
     fn set_logger(&mut self, logger: Logger) {
         self.logger = logger;
     }
@@ -499,6 +503,10 @@ impl Sink<CowRpcMessage> for CowMessageSink {
 }
 
 impl LoggerObject for CowMessageSink {
+    fn get_logger(&self) -> Logger {
+        self.logger.clone()
+    }
+
     fn set_logger(&mut self, logger: Logger) {
         self.logger = logger;
     }

--- a/cowrpc/src/transport/websocket_listener.rs
+++ b/cowrpc/src/transport/websocket_listener.rs
@@ -1,6 +1,6 @@
 use crate::error::{CowRpcError, Result};
 use crate::transport::websocket::{CowWebSocketStream, WebSocketTransport};
-use crate::transport::{CowFuture, CowStream, Listener, MessageInterceptor, TransportError};
+use crate::transport::{BoxStream, CowFuture, Listener, MessageInterceptor, TransportError};
 use async_trait::async_trait;
 use async_tungstenite::tokio::accept_async;
 use slog::Logger;
@@ -34,7 +34,7 @@ impl Listener for WebSocketListener {
         }
     }
 
-    async fn incoming(self) -> CowStream<CowFuture<Self::TransportInstance>> {
+    async fn incoming(self) -> BoxStream<CowFuture<Self::TransportInstance>> {
         let WebSocketListener {
             listener,
             tls_acceptor,
@@ -51,7 +51,7 @@ impl Listener for WebSocketListener {
                 Box::pin(accept_stream(tcp_stream, tls_acceptor.clone(), cbh, logger_clone))
                     as CowFuture<Self::TransportInstance>,
             )
-        })) as CowStream<CowFuture<Self::TransportInstance>>
+        })) as BoxStream<CowFuture<Self::TransportInstance>>
     }
 
     fn set_msg_interceptor(&mut self, cb_handler: Box<dyn MessageInterceptor>) {


### PR DESCRIPTION
J'ai ajouté le peer_id et le router_id pour les peers également.
De plus, puisque le bastion ne s'identifiera plus sur le réseau Cow, j'ai créé un logger par défaut dans le bastion pour y indiquer un type "bastion peer".  Donc au final, nous avons des traces qui ressemblent à ça : 

2021-06-18T10:56:14.768257300-04:00 DEBUG cowrpc::transport::websocket - >> Http Request, peer_id: 0xAD7FE3C9, router_id: 0xAD7F0000, **type: bastion peer**
2021-06-18T10:56:14.768836311-04:00 DEBUG cowrpc::transport::websocket - << Http Request, remote_addr: , peer_id: 0xAD7FE3C9, router_id: 0xAD7F0000, type: router
2021-06-18T10:56:14.768892085-04:00 DEBUG cowrpc::transport::websocket - >> Http Request, den_id: 327594, remote_addr: , peer_id: 0xAD7FE7EE, router_id: 0xAD7F0000, type: router
2021-06-18T10:56:14.863739306-04:00 DEBUG cowrpc::transport::websocket - << Http Response, den_id: 327594, remote_addr: , peer_id: 0xAD7FE7EE, router_id: 0xAD7F0000, type: router
2021-06-18T10:56:14.864080522-04:00 DEBUG cowrpc::transport::websocket - >> Http Response, remote_addr: , peer_id: 0xAD7FE3C9, router_id: 0xAD7F0000, type: router
2021-06-18T10:56:14.866193356-04:00 DEBUG cowrpc::transport::websocket - << Http Response, peer_id: 0xAD7FE3C9, router_id: 0xAD7F0000, **type: bastion peer**

On peut donc suivre une requête : 
1 - Le bastion peer envoie la requête http vers un agent
2 - Le router reçoit la requête
3 - Il forward la requête au bon agent
4 - Le router reçoit la réponse de l'agent
5 - Le router renvoie la requête au peer ayant fait la requête, le bastion peer dans ce cas
6 - Le bastion peer reçoit la réponse.